### PR TITLE
Fix Cython warnings

### DIFF
--- a/afs/_pts.pyx
+++ b/afs/_pts.pyx
@@ -112,7 +112,6 @@ cdef class PTEntry:
 cdef int _ptentry_from_c(PTEntry p_entry, prcheckentry * c_entry) except -1:
     if p_entry is None:
         raise TypeError
-        return -1
 
     p_entry.flags = c_entry.flags
     p_entry.id = c_entry.id
@@ -127,7 +126,6 @@ cdef int _ptentry_from_c(PTEntry p_entry, prcheckentry * c_entry) except -1:
 cdef int _ptentry_to_c(prcheckentry * c_entry, PTEntry p_entry) except -1:
     if p_entry is None:
         raise TypeError
-        return -1
 
     c_entry.flags = p_entry.flags
     c_entry.id = p_entry.id

--- a/afs/_pts.pyx
+++ b/afs/_pts.pyx
@@ -225,7 +225,9 @@ cdef class PTS:
 
         self.cell = info.name
 
-        if sec > 0:
+        if sec == 0:
+            sc = rxnull_NewClientSecurityObject()
+        else:
             strncpy(prin.cell, info.name, sizeof(prin.cell))
             prin.instance[0] = 0
             strncpy(prin.name, "afs", sizeof(prin.name))
@@ -235,6 +237,7 @@ cdef class PTS:
                 if sec >= 2:
                     # No really - we wanted authentication
                     pyafs_error(code)
+                sc = rxnull_NewClientSecurityObject()
                 sec = 0
             else:
                 if sec == 3:
@@ -244,11 +247,7 @@ cdef class PTS:
                 sc = rxkad_NewClientSecurityObject(level, &token.sessionKey,
                                                    token.kvno, token.ticketLen,
                                                    token.ticket)
-
-        if sec == 0:
-            sc = rxnull_NewClientSecurityObject()
-        else:
-            sec = 2
+                sec = 2
 
         memset(serverconns, 0, sizeof(serverconns))
         for 0 <= i < info.numServers:

--- a/afs/_util.pyx
+++ b/afs/_util.pyx
@@ -12,7 +12,7 @@ cdef int _init = 0
 
 # pioctl convenience wrappers
 
-cdef extern int pioctl_read(char *dir, afs_int32 op, void *buffer, unsigned short size, afs_int32 follow) except -1:
+cdef int pioctl_read(char *dir, afs_int32 op, void *buffer, unsigned short size, afs_int32 follow) except -1:
     cdef ViceIoctl blob
     cdef afs_int32 code
     blob.in_size  = 0
@@ -26,7 +26,7 @@ cdef extern int pioctl_read(char *dir, afs_int32 op, void *buffer, unsigned shor
     pyafs_error(code)
     return code
 
-cdef extern int pioctl_write(char *dir, afs_int32 op, char *buffer, afs_int32 follow) except -1:
+cdef int pioctl_write(char *dir, afs_int32 op, char *buffer, afs_int32 follow) except -1:
     cdef ViceIoctl blob
     cdef afs_int32 code
     blob.cin = buffer


### PR DESCRIPTION
Fixes

```
warning: afs/_util.pyx:15:5: Function 'pioctl_read' previously declared as 'private'
warning: afs/_util.pyx:29:5: Function 'pioctl_write' previously declared as 'private'
warning: afs/_pts.pyx:115:8: Unreachable code
warning: afs/_pts.pyx:130:8: Unreachable code
afs/_pts.c: In function ‘__pyx_pf_3afs_4_pts_3PTS___cinit__’:
afs/_pts.c:2999:56: warning: ‘__pyx_v_sc’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     (__pyx_v_serverconns[__pyx_v_i]) = rx_NewConnection((__pyx_v_info.hostAddr[__pyx_v_i]).sin_addr.s_addr, (__pyx_v_info.hostAddr[__pyx_v_i]).sin_port, PRSRV, __pyx_v_sc, __pyx_t_9);
                                                        ^
```
