### PR TITLE
Python 3 support

### DIFF
--- a/afs/_acl.pyx
+++ b/afs/_acl.pyx
@@ -1,5 +1,6 @@
+# cython: c_string_type=str, c_string_encoding=ascii
 from afs._util cimport *
-from afs._util import pyafs_error
+from afs._util import path_to_bytes
 
 cdef extern from "afs/prs_fs.h":
     enum:
@@ -34,15 +35,15 @@ USR7 = PRSFS_USR7
 
 DEF MAXSIZE = 2048
 
-def getAcl(char* dir, int follow=1):
+def getAcl(dir, int follow=1):
     cdef char space[MAXSIZE]
-    pioctl_read(dir, VIOCGETAL, space, MAXSIZE, follow)
+    pioctl_read(path_to_bytes(dir), VIOCGETAL, space, MAXSIZE, follow)
     return space
 
-def getCallerAccess(char *dir, int follow=1):
+def getCallerAccess(dir, int follow=1):
     cdef vcxstat2 stat
-    pioctl_read(dir, VIOC_GETVCXSTATUS2, <void*>&stat, sizeof(vcxstat2), follow)
+    pioctl_read(path_to_bytes(dir), VIOC_GETVCXSTATUS2, <void*>&stat, sizeof(vcxstat2), follow)
     return stat.callerAccess
 
-def setAcl(char* dir, char* acl, int follow=1):
-    pioctl_write(dir, VIOCSETAL, acl, follow)
+def setAcl(dir, char* acl, int follow=1):
+    pioctl_write(path_to_bytes(dir), VIOCSETAL, acl, follow)

--- a/afs/_fs.pyx
+++ b/afs/_fs.pyx
@@ -1,9 +1,10 @@
+# cython: c_string_type=str, c_string_encoding=ascii
 from afs._util cimport *
-from afs._util import pyafs_error
+from afs._util import path_to_bytes
 
-def whichcell(char* path):
+def whichcell(path):
     """Determine which AFS cell a particular path is in."""
     cdef char cell[MAXCELLCHARS]
 
-    pioctl_read(path, VIOC_FILE_CELL_NAME, cell, sizeof(cell), 1)
+    pioctl_read(path_to_bytes(path), VIOC_FILE_CELL_NAME, cell, sizeof(cell), 1)
     return cell

--- a/afs/_pts.pyx
+++ b/afs/_pts.pyx
@@ -1,3 +1,4 @@
+# cython: c_string_type=str, c_string_encoding=ascii
 from afs._util cimport *
 from afs._util import pyafs_error
 import re

--- a/afs/_pts.pyx
+++ b/afs/_pts.pyx
@@ -112,7 +112,6 @@ cdef class PTEntry:
 cdef int _ptentry_from_c(PTEntry p_entry, prcheckentry * c_entry) except -1:
     if p_entry is None:
         raise TypeError
-        return -1
 
     p_entry.flags = c_entry.flags
     p_entry.id = c_entry.id
@@ -127,7 +126,6 @@ cdef int _ptentry_from_c(PTEntry p_entry, prcheckentry * c_entry) except -1:
 cdef int _ptentry_to_c(prcheckentry * c_entry, PTEntry p_entry) except -1:
     if p_entry is None:
         raise TypeError
-        return -1
 
     c_entry.flags = p_entry.flags
     c_entry.id = p_entry.id

--- a/afs/_pts.pyx
+++ b/afs/_pts.pyx
@@ -225,7 +225,9 @@ cdef class PTS:
 
         self.cell = info.name
 
-        if sec > 0:
+        if sec == 0:
+            sc = rxnull_NewClientSecurityObject()
+        else:
             strncpy(prin.cell, info.name, sizeof(prin.cell))
             prin.instance[0] = 0
             strncpy(prin.name, "afs", sizeof(prin.name))
@@ -235,6 +237,7 @@ cdef class PTS:
                 if sec >= 2:
                     # No really - we wanted authentication
                     pyafs_error(code)
+                sc = rxnull_NewClientSecurityObject()
                 sec = 0
             else:
                 if sec == 3:
@@ -244,11 +247,7 @@ cdef class PTS:
                 sc = rxkad_NewClientSecurityObject(level, &token.sessionKey,
                                                    token.kvno, token.ticketLen,
                                                    token.ticket)
-
-        if sec == 0:
-            sc = rxnull_NewClientSecurityObject()
-        else:
-            sec = 2
+                sec = 2
 
         memset(serverconns, 0, sizeof(serverconns))
         for 0 <= i < info.numServers:

--- a/afs/_util.pyx
+++ b/afs/_util.pyx
@@ -1,7 +1,7 @@
 """
 General PyAFS utilities, such as error handling
 """
-
+# cython: c_string_type=str, c_string_encoding=ascii
 import sys
 
 # otherwise certain headers are unhappy
@@ -18,6 +18,7 @@ cdef int pioctl_read(char *dir, afs_int32 op, void *buffer, unsigned short size,
     blob.in_size  = 0
     blob.out_size = size
     blob.out = buffer
+
     code = pioctl(dir, op, &blob, follow)
     # This might work with the rest of OpenAFS, but I'm not convinced
     # the rest of it is consistent
@@ -66,3 +67,8 @@ def pyafs_error(code):
 
     if code != 0:
         raise AFSException(code)
+
+def path_to_bytes(path):
+    if isinstance(path, unicode):
+        return path.encode(sys.getfilesystemencoding(), 'surrogateescape')
+    return path

--- a/afs/_util.pyx
+++ b/afs/_util.pyx
@@ -12,7 +12,7 @@ cdef int _init = 0
 
 # pioctl convenience wrappers
 
-cdef extern int pioctl_read(char *dir, afs_int32 op, void *buffer, unsigned short size, afs_int32 follow) except -1:
+cdef int pioctl_read(char *dir, afs_int32 op, void *buffer, unsigned short size, afs_int32 follow) except -1:
     cdef ViceIoctl blob
     cdef afs_int32 code
     blob.in_size  = 0
@@ -26,7 +26,7 @@ cdef extern int pioctl_read(char *dir, afs_int32 op, void *buffer, unsigned shor
     pyafs_error(code)
     return code
 
-cdef extern int pioctl_write(char *dir, afs_int32 op, char *buffer, afs_int32 follow) except -1:
+cdef int pioctl_write(char *dir, afs_int32 op, char *buffer, afs_int32 follow) except -1:
     cdef ViceIoctl blob
     cdef afs_int32 code
     blob.cin = buffer

--- a/afs/acl.py
+++ b/afs/acl.py
@@ -119,7 +119,7 @@ class ACL(object):
     def set(self, user, bitmask, negative=False):
         """Set the bitmask for a given user"""
         if bitmask < 0 or bitmask > max(_char2bit.values()):
-            raise ValueError, "Invalid bitmask"
+            raise ValueError("Invalid bitmask")
         if negative:
             self.neg[user] = bitmask
         else:

--- a/afs/acl.py
+++ b/afs/acl.py
@@ -11,7 +11,7 @@ _canonical = {
     "none": "",
 }
 
-_reverseCanonical = dict((y, x) for (x, y) in _canonical.iteritems())
+_reverseCanonical = dict((y, x) for (x, y) in _canonical.items())
 
 _charBitAssoc = [
     ('r', READ),

--- a/afs/fs.py
+++ b/afs/fs.py
@@ -6,7 +6,7 @@ def inafs(path):
     """Return True if a path is in AFS."""
     try:
         whichcell(path)
-    except OSError, e:
+    except OSError as e:
         if e.errno in (errno.EINVAL, errno.ENOENT):
             return False
 

--- a/afs/pts.py
+++ b/afs/pts.py
@@ -381,7 +381,7 @@ class PTS(_pts.PTS):
                                 elt)
             return ident
 
-        elif isinstance(ident, basestring):
+        elif isinstance(ident, (str, bytes)):
             return PTEntry(self, name=ident)
         else:
             return PTEntry(self, id=ident)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def PyAFSExtension(module, *args, **kwargs):
 
 setup(
     name="PyAFS",
-    version="0.1.1",
+    version="0.1.2",
     description="PyAFS - Python bindings for AFS",
     author="Evan Broder",
     author_email="broder@mit.edu",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if os.path.exists('%s/lib/libafsauthent_pic.a' % root) or os.path.exists('%s/lib
     suffix = '_pic'
 else:
     suffix = ''
-libraries = ['afsauthent%s' % suffix, 'afsrpc%s' % suffix, 'resolv']
+libraries = ['afsauthent%s' % suffix, 'afsrpc%s' % suffix, 'rokenafs', 'afshcrypto', 'resolv']
 define_macros = [('AFS_PTHREAD_ENV', None)]
 
 def PyAFSExtension(module, *args, **kwargs):


### PR DESCRIPTION
Paths are handled using Python 3's standard "surrogateescape" encoding. All other strings are handled as pure ASCII.

This also supports modern OpenAFS where some functions were split out into new libraries.

Finally, I included Anders's old commits to remove compiler warnings.